### PR TITLE
Supply crate QOL tweaks

### DIFF
--- a/Missionframework/scripts/client/ammoboxes/ammobox_action_manager.sqf
+++ b/Missionframework/scripts/client/ammoboxes/ammobox_action_manager.sqf
@@ -61,7 +61,7 @@ while {true} do {
                     true,
                     true,
                     "",
-                    "build_confirmed == 0 && (_this distance _target < 5) && (vehicle player == player)"];
+                    "build_confirmed == 0 && (_this distance _target < 7) && (vehicle player == player)"];
                 _b_action_id1 = _next_box addAction [
                     "<t color='#FFFF00'>" + localize "STR_ACTION_LOAD_BOX" + "</t>",
                     {[_this select 0] call do_load_box;},
@@ -70,7 +70,7 @@ while {true} do {
                     true,
                     true,
                     "",
-                    "build_confirmed == 0 && (_this distance _target < 5) && (vehicle player == player)"];
+                    "build_confirmed == 0 && (_this distance _target < 7) && (vehicle player == player)"];
                 _b_action_id3 = _next_box addAction [
                     "<t color='#FFFF00'>" + localize "STR_ACTION_CRATE_VALUE" + "</t>",
                     {[_this select 0] call KPLIB_fnc_checkCrateValue;uiSleep 3; hint "";},
@@ -79,7 +79,7 @@ while {true} do {
                     true,
                     true,
                     "",
-                    "build_confirmed == 0 && (_this distance _target < 5) && (vehicle player == player)"];
+                    "build_confirmed == 0 && (_this distance _target < 7) && (vehicle player == player)"];
                 _b_action_id4 = _next_box addAction [
                     "<t color='#FFFF00'>" + localize "STR_ACTION_CRATE_PUSH" + "</t>",
                     {(_this select 0) setPos ((_this select 0) getPos [1, (player getDir (_this select 0))]);},

--- a/Missionframework/scripts/client/ammoboxes/ammobox_action_manager.sqf
+++ b/Missionframework/scripts/client/ammoboxes/ammobox_action_manager.sqf
@@ -53,7 +53,7 @@ while {true} do {
         {
             _next_box = _x;
             if (!(_next_box in _managed_boxes) && ( isNull  attachedTo _next_box )) then {
-                _b_action_id2 = _next_box addAction [
+                _b_action_id1 = _next_box addAction [
                     "<t color='#FFFF00'>" + localize "STR_ACTION_STORE_CRATE" + "</t>",
                     {[(_this select 0), (nearestObjects [player,KPLIB_storageBuildings,20]) select 0,true] call KPLIB_fnc_crateToStorage;},
                     "",
@@ -62,7 +62,7 @@ while {true} do {
                     true,
                     "",
                     "build_confirmed == 0 && (_this distance _target < 7) && (vehicle player == player)"];
-                _b_action_id1 = _next_box addAction [
+                _b_action_id2 = _next_box addAction [
                     "<t color='#FFFF00'>" + localize "STR_ACTION_LOAD_BOX" + "</t>",
                     {[_this select 0] call do_load_box;},
                     "",
@@ -90,8 +90,8 @@ while {true} do {
                     "",
                     "build_confirmed == 0 && (_this distance _target < 7) && (vehicle player == player)"];
 
-                _next_box setVariable ["GRLIB_ammo_box_action", _b_action_id1, false];
-                _next_box setVariable ["KP_crate_store_action", _b_action_id2, false];
+                _next_box setVariable ["KP_crate_store_action", _b_action_id1, false];
+                _next_box setVariable ["GRLIB_ammo_box_action", _b_action_id2, false];
                 _next_box setVariable ["KP_crate_value_action", _b_action_id3, false];
                 _next_box setVariable ["KP_crate_push_action", _b_action_id4, false];
                 _managed_boxes pushback _next_box;

--- a/Missionframework/scripts/client/ammoboxes/ammobox_action_manager.sqf
+++ b/Missionframework/scripts/client/ammoboxes/ammobox_action_manager.sqf
@@ -53,18 +53,18 @@ while {true} do {
         {
             _next_box = _x;
             if (!(_next_box in _managed_boxes) && ( isNull  attachedTo _next_box )) then {
-                _b_action_id1 = _next_box addAction [
-                    "<t color='#FFFF00'>" + localize "STR_ACTION_LOAD_BOX" + "</t>",
-                    {[_this select 0] call do_load_box;},
+                _b_action_id2 = _next_box addAction [
+                    "<t color='#FFFF00'>" + localize "STR_ACTION_STORE_CRATE" + "</t>",
+                    {[(_this select 0), (nearestObjects [player,KPLIB_storageBuildings,20]) select 0,true] call KPLIB_fnc_crateToStorage;},
                     "",
                     -501,
                     true,
                     true,
                     "",
                     "build_confirmed == 0 && (_this distance _target < 5) && (vehicle player == player)"];
-                _b_action_id2 = _next_box addAction [
-                    "<t color='#FFFF00'>" + localize "STR_ACTION_STORE_CRATE" + "</t>",
-                    {[(_this select 0), (nearestObjects [player,KPLIB_storageBuildings,20]) select 0,true] call KPLIB_fnc_crateToStorage;},
+                _b_action_id1 = _next_box addAction [
+                    "<t color='#FFFF00'>" + localize "STR_ACTION_LOAD_BOX" + "</t>",
+                    {[_this select 0] call do_load_box;},
                     "",
                     -502,
                     true,
@@ -88,7 +88,7 @@ while {true} do {
                     true,
                     false,
                     "",
-                    "build_confirmed == 0 && (_this distance _target < 5) && (vehicle player == player)"];
+                    "build_confirmed == 0 && (_this distance _target < 7) && (vehicle player == player)"];
 
                 _next_box setVariable ["GRLIB_ammo_box_action", _b_action_id1, false];
                 _next_box setVariable ["KP_crate_store_action", _b_action_id2, false];

--- a/Missionframework/scripts/client/ammoboxes/ammobox_action_manager.sqf
+++ b/Missionframework/scripts/client/ammoboxes/ammobox_action_manager.sqf
@@ -53,10 +53,43 @@ while {true} do {
         {
             _next_box = _x;
             if (!(_next_box in _managed_boxes) && ( isNull  attachedTo _next_box )) then {
-                _b_action_id1 = _next_box addAction ["<t color='#FFFF00'>" + localize "STR_ACTION_LOAD_BOX" + "</t>",{[_this select 0] call do_load_box;},"",-501,true,true,"","build_confirmed == 0 && (_this distance _target < 5) && (vehicle player == player)"];
-                _b_action_id2 = _next_box addAction ["<t color='#FFFF00'>" + localize "STR_ACTION_STORE_CRATE" + "</t>",{[(_this select 0), (nearestObjects [player,KPLIB_storageBuildings,20]) select 0,true] call KPLIB_fnc_crateToStorage;},"",-502,true,true,"","build_confirmed == 0 && (_this distance _target < 5) && (vehicle player == player)"];
-                _b_action_id3 = _next_box addAction ["<t color='#FFFF00'>" + localize "STR_ACTION_CRATE_VALUE" + "</t>",{[_this select 0] call KPLIB_fnc_checkCrateValue;uiSleep 3; hint "";},"",-503,true,true,"","build_confirmed == 0 && (_this distance _target < 5) && (vehicle player == player)"];
-                _b_action_id4 = _next_box addAction ["<t color='#FFFF00'>" + localize "STR_ACTION_CRATE_PUSH" + "</t>",{(_this select 0) setPos ((_this select 0) getPos [1, (player getDir (_this select 0))]);},"",-504,true,false,"","build_confirmed == 0 && (_this distance _target < 5) && (vehicle player == player)"];
+                _b_action_id1 = _next_box addAction [
+                    "<t color='#FFFF00'>" + localize "STR_ACTION_LOAD_BOX" + "</t>",
+                    {[_this select 0] call do_load_box;},
+                    "",
+                    -501,
+                    true,
+                    true,
+                    "",
+                    "build_confirmed == 0 && (_this distance _target < 5) && (vehicle player == player)"];
+                _b_action_id2 = _next_box addAction [
+                    "<t color='#FFFF00'>" + localize "STR_ACTION_STORE_CRATE" + "</t>",
+                    {[(_this select 0), (nearestObjects [player,KPLIB_storageBuildings,20]) select 0,true] call KPLIB_fnc_crateToStorage;},
+                    "",
+                    -502,
+                    true,
+                    true,
+                    "",
+                    "build_confirmed == 0 && (_this distance _target < 5) && (vehicle player == player)"];
+                _b_action_id3 = _next_box addAction [
+                    "<t color='#FFFF00'>" + localize "STR_ACTION_CRATE_VALUE" + "</t>",
+                    {[_this select 0] call KPLIB_fnc_checkCrateValue;uiSleep 3; hint "";},
+                    "",
+                    -503,
+                    true,
+                    true,
+                    "",
+                    "build_confirmed == 0 && (_this distance _target < 5) && (vehicle player == player)"];
+                _b_action_id4 = _next_box addAction [
+                    "<t color='#FFFF00'>" + localize "STR_ACTION_CRATE_PUSH" + "</t>",
+                    {(_this select 0) setPos ((_this select 0) getPos [1, (player getDir (_this select 0))]);},
+                    "",
+                    -504,
+                    true,
+                    false,
+                    "",
+                    "build_confirmed == 0 && (_this distance _target < 5) && (vehicle player == player)"];
+
                 _next_box setVariable ["GRLIB_ammo_box_action", _b_action_id1, false];
                 _next_box setVariable ["KP_crate_store_action", _b_action_id2, false];
                 _next_box setVariable ["KP_crate_value_action", _b_action_id3, false];


### PR DESCRIPTION
Small QOL updates for players: 
- Allow crate interactions from up to 7m away, up from 5m
- The STORE CRATE action now has priority over LOAD CRATE near FOBs
    - This should make loading crates at FOBs easier, as a player only has to approach it and press Space

... in theory, anyway