### PR TITLE
Disconnect UAV on death

### DIFF
--- a/Missionframework/onPlayerRespawn.sqf
+++ b/Missionframework/onPlayerRespawn.sqf
@@ -2,6 +2,10 @@ waitUntil {!isNil "KPLIB_initServer"};
 
 params ["_newUnit", "_oldUnit"];
 
+if (!isNil "KP_liberation_disconnectUAV_on_death") then {
+    getConnectedUAV _oldunit action ["UAVTerminalReleaseConnection", _oldunit];
+};
+
 if (isNil "GRLIB_respawn_loadout") then {
     removeAllWeapons player;
     removeAllItems player;

--- a/Missionframework/scripts/shared/fetch_params.sqf
+++ b/Missionframework/scripts/shared/fetch_params.sqf
@@ -79,6 +79,7 @@ if(isServer) then {
 
     // Gameplay Options
     ["--- Gameplay Options ---", "PARAM"] call KPLIB_fnc_log;
+    GET_PARAM_BOOL(KP_liberation_disconnectUAV_on_death, "DisconnectUAV", 1);
     GET_PARAM_BOOL(GRLIB_fatigue, "Fatigue", 1);
     GET_PARAM_BOOL(KPLIB_sway, "WeaponSway", 1);
     GET_PARAM_BOOL(KP_liberation_arsenalUsePreset, "ArsenalUsePreset", 1);

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -1486,6 +1486,9 @@
             <Korean>군수물자 생산 비율</Korean>
             <Czech>Násobitel zdrojů</Czech>
         </Key>
+        <Key ID="STR_PARAMS_DISCONNECTUAV">
+            <Original>Disconnect from UAV on death</Original>
+        </Key>
         <Key ID="STR_PARAMS_FATIGUE">
             <Original>Stamina</Original>
             <French>Stamina</French>

--- a/Missionframework/ui/mission_params.hpp
+++ b/Missionframework/ui/mission_params.hpp
@@ -209,6 +209,12 @@ class Params {
         texts[] = {""};
         default = "";
     };
+    class DisconnectUAV {
+        title = $STR_PARAMS_DISCONNECTUAV;
+        values[] = {0, 1};
+        texts[] = {$STR_PARAMS_DISABLED, $STR_PARAMS_ENABLED};
+        default = 1;
+    };
     class Fatigue {
         title = $STR_PARAMS_FATIGUE;
         values[] = {0, 1};


### PR DESCRIPTION
This adds a parameter that allows automatically disconnecting from UAVs on death, allowing players to reconnect to them